### PR TITLE
modernized

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,27 +1,27 @@
-'use strict';
-const execa = require('execa');
-const plist = require('simple-plist');
-const objType = require('obj-type');
-const lowercaseFirstKeys = require('lowercase-first-keys');
+import {platform} from 'node:process';
+import execa from 'execa';
+import {parse} from 'simple-plist';
+import objType from 'obj-type';
+import lowercaseFirstKeys from 'lowercase-first-keys';
 
-module.exports = () => {
-	if (process.platform !== 'darwin') {
-		return Promise.reject(new Error('Only OS X systems are supported'));
+export default platform === 'darwin'
+	? async () => {
+		const {stdout} = await execa('ioreg', ['-n', 'AppleSmartBattery', '-r', '-a']);
+		const batteries = parse(stdout);
+
+		if (!batteries || batteries.length === 0) {
+			throw new Error('This computer doesn\'t have a battery');
+		}
+
+		const battery = lowercaseFirstKeys(batteries[0]);
+		const result = {};
+
+		for (const key of Object.keys(battery)) {
+			const value = battery[key];
+			result[key] = objType(value) === 'object' ? lowercaseFirstKeys(value) : value;
+		}
+
+
+		return result;
 	}
-
-	return execa.stdout('ioreg', ['-n', 'AppleSmartBattery', '-r', '-a'])
-		.then(plist.parse)
-		.then(batteries => {
-			if (!batteries || batteries.length === 0) {
-				throw new Error('This computer doesn\'t have a battery');
-			}
-
-			const battery = lowercaseFirstKeys(batteries[0]);
-
-			return Object.keys(battery).reduce((obj, x) => {
-				const val = battery[x];
-				obj[x] = objType(val) === 'object' ? lowercaseFirstKeys(val) : val;
-				return obj;
-			}, {});
-		});
-};
+	: () => Promise.reject(new Error('Only OS X systems are supported'));

--- a/index.js
+++ b/index.js
@@ -1,12 +1,15 @@
 import {platform} from 'node:process';
-import execa from 'execa';
+import {promisify} from 'node:util';
+import {exec} from 'node:child_process';
 import {parse} from 'simple-plist';
 import objType from 'obj-type';
 import lowercaseFirstKeys from 'lowercase-first-keys';
 
+const run = promisify(exec);
+
 export default platform === 'darwin'
 	? async () => {
-		const {stdout} = await execa('ioreg', ['-n', 'AppleSmartBattery', '-r', '-a']);
+		const {stdout} = await run('ioreg -n AppleSmartBattery -r -a');
 		const batteries = parse(stdout);
 
 		if (!batteries || batteries.length === 0) {
@@ -20,7 +23,6 @@ export default platform === 'darwin'
 			const value = battery[key];
 			result[key] = objType(value) === 'object' ? lowercaseFirstKeys(value) : value;
 		}
-
 
 		return result;
 	}

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
 		"email": "andreasgillstrom@gmail.com",
 		"url": "github.com/gillstrom"
 	},
+	"type": "module",
 	"engines": {
-		"node": ">=4"
+		"node": "12.20"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -28,10 +29,10 @@
 		"osx"
 	],
 	"dependencies": {
-		"execa": "^0.7.0",
-		"lowercase-first-keys": "^1.0.0",
-		"obj-type": "^1.0.0",
-		"simple-plist": "0.2.1"
+		"execa": "^5.1.1",
+		"lowercase-first-keys": "^1.0.1",
+		"obj-type": "^1.0.1",
+		"simple-plist": "^1.1.1"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
 		"osx"
 	],
 	"dependencies": {
-		"execa": "^5.1.1",
 		"lowercase-first-keys": "^1.0.1",
 		"obj-type": "^1.0.1",
 		"simple-plist": "^1.1.1"

--- a/readme.md
+++ b/readme.md
@@ -13,27 +13,24 @@ $ npm install --save osx-battery
 ## Usage
 
 ```js
-const osxBattery = require('osx-battery');
+import osxBattery from 'osx-battery';
 
-osxBattery().then(res => {
-	console.log(res);
-	/*
-	{
-		adapterInfo: 0,
-		amperage: -1178,
-		avgTimeToEmpty: 380,
-		avgTimeToFull: 65535,
-		batteryInstalled: true,
-		batteryInvalidWakeSeconds: 30,
-		batterySerialNumber: 'C01447304DPF9CRA8',
-		bootPathUpdated: 1431448419,
-		cellVoltage: [ 4098, 4105, 4104, 0 ],
-		currentCapacity: 7468,
-		cycleCount: 39,
-		...
-	}
-	*/
-});
+const res = await osxBattery();
+console.log(res);
+/* {
+	adapterInfo: 0,
+	amperage: -1178,
+	avgTimeToEmpty: 380,
+	avgTimeToFull: 65535,
+	batteryInstalled: true,
+	batteryInvalidWakeSeconds: 30,
+	batterySerialNumber: 'C01447304DPF9CRA8',
+	bootPathUpdated: 1431448419,
+	cellVoltage: [ 4098, 4105, 4104, 0 ],
+	currentCapacity: 7468,
+	cycleCount: 39,
+	...
+} */
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -1,8 +1,8 @@
 import test from 'ava';
-import m from '.';
+import m from './index.js';
 
-test(async t => {
-	const res = await m();
-	t.is(typeof res.adapterInfo, 'number');
-	t.is(typeof res.iORegistryEntryName, 'string');
+test('get battery', async t => {
+	const result = await m();
+	t.is(typeof result.adapterInfo, 'number');
+	t.is(typeof result.iORegistryEntryName, 'string');
 });


### PR DESCRIPTION
You did always depend on latest xo & ava
it's complaining on some new rules like 
- don't use reduce
- use async/await instead of then
- require explicit import path
- use node: prefix to import node modules

...So i fixed all of it.
Also updated all dependencies to latest version to reduce dedupe

sindresorhus is going to update execa to become a ESM only package and only require node v12+ (https://github.com/sindresorhus/meta/discussions/15)
I happen to know that one of his sub dependency (trim last line) is already ESM only 
So i also made the switch to ESM only and switched commonjs to ESM

Speaking of execa... I notice that #1 don't seem to be published to npm at all.
still using child_process exec and Promise polyfill...
I do think execa should never have been included... it's quite large/bloated for such a small easy task to accomplish with just a simple child_process and util.promisify:
```js
const util = require('util');
const exec = util.promisify(require('child_process').exec);
```

https://npm.anvaka.com/#/view/2d/execa